### PR TITLE
Composer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ To install Null Number, follow these steps:
 
 1. Download & unzip the file and place the `nullnumber` directory into your `craft/plugins` directory
 2.  -OR- do a `git clone https://github.com/steverowling/nullnumber.git` directly into your `craft/plugins` folder.  You can then update it with `git pull`
-3. Install plugin in the Craft Control Panel under Settings > Plugins
-4. The plugin folder should be named `nullnumber` for Craft to see it.  GitHub recently started appending `-master` (the branch name) to the name of the folder for zip file downloads.
+3.  -OR- install with Composer via `composer require steverowling/nullnumber`
+4. Install plugin in the Craft Control Panel under Settings > Plugins
+5. The plugin folder should be named `nullnumber` for Craft to see it.  GitHub recently started appending `-master` (the branch name) to the name of the folder for zip file downloads.
 
 Null Number works on Craft 2.4.x and higher.
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+  "name": "steverowling/nullnumber",
+  "description": "Extension of the built-in Number field with a default value of null.",
+  "authors": [
+    {
+      "name": "Steve Rowling",
+      "homepage": "https://springworks.co.uk/"
+    }
+  ],
+  "type": "craft-plugin",
+  "require": {
+    "composer/installers": "~1.0"
+  }
+}


### PR DESCRIPTION
So Composer users can simply do `composer require steverowling/nullnumber`.
Would be much appreciated!

Ideally, you would push git tags for the versions as well, which is how composer picks up versions.
