### PR TITLE
Adding 2 new settings: inputSize, inputAlignment

### DIFF
--- a/fieldtypes/NullNumberFieldType.php
+++ b/fieldtypes/NullNumberFieldType.php
@@ -46,6 +46,18 @@ class NullNumberFieldType extends NumberFieldType
     }
 
     /**
+     * @inheritDoc ISavableComponentType::getSettingsHtml()
+     *
+     * @return string|null
+     */
+    public function getSettingsHtml()
+    {
+        return craft()->templates->render('nullnumber/settings', array(
+            'settings' => $this->settings
+        ));
+    }
+
+    /**
      * @inheritDoc IFieldType::getInputHtml()
      *
      * @param string $name
@@ -60,20 +72,18 @@ class NullNumberFieldType extends NumberFieldType
             $value = null;
         }
 
-        if ($value == null)
+        $vars = array(
+            'name'  => $name,
+            'size'  => $this->settings->inputSize,
+            'value' => $value === null ? '' : craft()->numberFormatter->formatDecimal($value, false),
+        );
+
+        if ($this->settings['inputAlignment'])
         {
-            return craft()->templates->render('_includes/forms/text', array(
-                'name'  => $name,
-                'value' => '',
-                'size'  => 5
-            ));
+            $vars['style'] = 'direction: ' . $this->settings['inputAlignment'] . ';';
         }
 
-        return craft()->templates->render('_includes/forms/text', array(
-            'name'  => $name,
-            'value' => craft()->numberFormatter->formatDecimal($value, false),
-            'size'  => 5
-        ));
+        return craft()->templates->render('_includes/forms/text', $vars);
     }
 
     /**
@@ -94,4 +104,10 @@ class NullNumberFieldType extends NumberFieldType
             return LocalizationHelper::normalizeNumber($data);
         }
     }
+
+    protected function getSettingsModel()
+    {
+        return new NullNumber_SettingsModel();
+    }
+
 }

--- a/models/NullNumber_SettingsModel.php
+++ b/models/NullNumber_SettingsModel.php
@@ -1,0 +1,13 @@
+<?php
+namespace Craft;
+
+class NullNumber_SettingsModel extends NumberFieldTypeSettingsModel
+{
+    protected function defineAttributes()
+    {
+        return array_merge(parent::defineAttributes(), array(
+            'inputSize' => array(AttributeType::Number, 'min' => 1, 'default' => 5),
+            'inputAlignment' => array(AttributeType::String),
+        ));
+    }
+}

--- a/templates/settings.twig
+++ b/templates/settings.twig
@@ -1,0 +1,24 @@
+{% import "_includes/forms" as forms %}
+{% include '_components/fieldtypes/Number/settings' %}
+
+{{ forms.textField({
+  label: "Input Size"|t,
+  id: 'inputSize',
+  name: 'inputSize',
+  value: settings.inputSize,
+  size: 5,
+  errors: settings.getErrors('inputSize')
+}) }}
+
+{{ forms.selectField({
+  label: "Input Alignment"|t,
+  id: 'inputAlignment',
+  name: 'inputAlignment',
+  value: settings.inputAlignment,
+  errors: settings.getErrors('inputAlignment'),
+  options: {
+    '': 'Locale Default'|t,
+    'rtl': 'Right'|t,
+    'ltr': 'Left'|t,
+  }
+}) }}


### PR DESCRIPTION
Number inputs were locked to a `size` attribute of 5, so they would often get cut off with larger numbers.
I took the opportunity to also add an alignment option so number could optionally be aligned right, which is common for numbers.
